### PR TITLE
feat(#13): Implement DELETE /api/v1/follows endpoint

### DIFF
--- a/app/controllers/api/v1/follows_controller.rb
+++ b/app/controllers/api/v1/follows_controller.rb
@@ -27,6 +27,41 @@ class Api::V1::FollowsController < Api::BaseController
     end
   end
 
+  def destroy
+    followed_user = User.find_by(id: params[:followed_id])
+
+    unless followed_user
+      render json: {
+        error: "User not found",
+        message: "The user you want to unfollow does not exist"
+      }, status: :not_found
+      return
+    end
+
+    # Find the follow relationship
+    follow = current_user.active_follows.find_by(followed: followed_user)
+
+    unless follow
+      render json: {
+        error: "Follow relationship not found",
+        message: "You are not following this user"
+      }, status: :not_found
+      return
+    end
+
+    if follow.destroy
+      render json: {
+        message: "Successfully unfollowed user",
+        follow: follow_json(follow)
+      }, status: :ok
+    else
+      render json: {
+        error: "Unable to unfollow user",
+        message: "An error occurred while unfollowing the user"
+      }, status: :unprocessable_content
+    end
+  end
+
   private
 
   def follow_json(follow)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,4 @@ class User < ApplicationRecord
   def follow(other_user)
     active_follows.create(followed: other_user)
   end
-
-  def unfollow(other_user)
-    follow_relationship = active_follows.find_by(followed: other_user)
-    follow_relationship&.destroy
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 100 }
 
   def latest_sleep_record
-    sleep_records.order(created_at: :desc).first
+    sleep_records.order(id: :desc).first
   end
 
   def following?(other_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,9 @@ class User < ApplicationRecord
   def follow(other_user)
     active_follows.create(followed: other_user)
   end
+
+  def unfollow(other_user)
+    follow_relationship = active_follows.find_by(followed: other_user)
+    follow_relationship&.destroy
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "sleep_records", to: "sleep_records#create"
       post "follows", to: "follows#create"
+      delete "follows", to: "follows#destroy"
     end
   end
 

--- a/db/migrate/20250913165515_add_composite_index_to_follows.rb
+++ b/db/migrate/20250913165515_add_composite_index_to_follows.rb
@@ -1,0 +1,12 @@
+class AddCompositeIndexToFollows < ActiveRecord::Migration[8.0]
+  def change
+    # Add composite index for efficient follow relationship lookups
+    # This optimizes queries like: follows.where(follower_id: X, followed_id: Y)
+    # Used in: FollowsController#destroy and Follow model uniqueness validation
+    add_index :follows, [:follower_id, :followed_id], unique: true, name: 'index_follows_on_follower_and_followed'
+    
+    # Remove follower_id index since it's redundant with the composite index
+    # Note: PostgreSQL can use the composite index for single-column lookups on follower_id
+    remove_index :follows, :follower_id
+  end
+end

--- a/db/migrate/20250913165515_add_composite_index_to_follows.rb
+++ b/db/migrate/20250913165515_add_composite_index_to_follows.rb
@@ -3,8 +3,8 @@ class AddCompositeIndexToFollows < ActiveRecord::Migration[8.0]
     # Add composite index for efficient follow relationship lookups
     # This optimizes queries like: follows.where(follower_id: X, followed_id: Y)
     # Used in: FollowsController#destroy and Follow model uniqueness validation
-    add_index :follows, [:follower_id, :followed_id], unique: true, name: 'index_follows_on_follower_and_followed'
-    
+    add_index :follows, [ :follower_id, :followed_id ], unique: true, name: 'index_follows_on_follower_and_followed'
+
     # Remove follower_id index since it's redundant with the composite index
     # Note: PostgreSQL can use the composite index for single-column lookups on follower_id
     remove_index :follows, :follower_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_11_020117) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_13_165515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,7 +20,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_11_020117) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["followed_id"], name: "index_follows_on_followed_id"
-    t.index ["follower_id"], name: "index_follows_on_follower_id"
+    t.index ["follower_id", "followed_id"], name: "index_follows_on_follower_and_followed", unique: true
   end
 
   create_table "sleep_records", force: :cascade do |t|

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -128,6 +128,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/RateLimitErrorResponse'
 
+    delete:
+      summary: Unfollow a user
+      description: |
+        Removes an existing follow relationship between the current user and another user.
+        
+        **Business Logic:**
+        - The follow relationship must exist before it can be deleted
+        - Both follower and followed users must exist
+        - Returns the details of the deleted follow relationship
+      operationId: deleteFollow
+      tags:
+        - Follows
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - user_id
+                - followed_id
+              properties:
+                user_id:
+                  type: integer
+                  description: The ID of the user who wants to unfollow (follower)
+                  example: 1
+                followed_id:
+                  type: integer
+                  description: The ID of the user to be unfollowed
+                  example: 2
+      responses:
+        '200':
+          description: Successfully unfollowed user
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FollowDeleteResponse'
+        '401':
+          description: Unauthorized - user not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not Found - followed user does not exist or follow relationship not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Entity - unable to delete follow relationship
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitErrorResponse'
+
 components:
   schemas:
     SleepRecord:
@@ -275,6 +337,18 @@ components:
         message:
           type: string
           example: "Successfully followed user"
+        follow:
+          $ref: '#/components/schemas/Follow'
+      required:
+        - message
+        - follow
+
+    FollowDeleteResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Successfully unfollowed user"
         follow:
           $ref: '#/components/schemas/Follow'
       required:

--- a/spec/controllers/api/v1/follows_controller_spec.rb
+++ b/spec/controllers/api/v1/follows_controller_spec.rb
@@ -103,4 +103,90 @@ RSpec.describe Api::V1::FollowsController, type: :controller do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    context 'when user_id is not provided' do
+      it 'returns unauthorized error' do
+        delete :destroy, params: { followed_id: followed.id }
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        )
+      end
+    end
+
+    context 'when user does not exist' do
+      it 'returns unauthorized error' do
+        delete :destroy, params: { user_id: 999999, followed_id: followed.id }
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        )
+      end
+    end
+
+    context 'when followed_id is not provided' do
+      it 'returns not found error' do
+        delete :destroy, params: { user_id: follower.id }
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'The user you want to unfollow does not exist'
+        )
+      end
+    end
+
+    context 'when followed user does not exist' do
+      it 'returns not found error' do
+        delete :destroy, params: { user_id: follower.id, followed_id: 999999 }
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'The user you want to unfollow does not exist'
+        )
+      end
+    end
+
+    context 'when both users exist' do
+      context 'and follow relationship exists' do
+        before { create(:follow, follower: follower, followed: followed) }
+
+        it 'destroys the follow relationship and returns 200' do
+          expect {
+            delete :destroy, params: { user_id: follower.id, followed_id: followed.id }
+          }.to change(Follow, :count).by(-1)
+
+          expect(response).to have_http_status(:ok)
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['message']).to eq('Successfully unfollowed user')
+
+          follow_data = response_body['follow']
+          expect(follow_data['follower_id']).to eq(follower.id)
+          expect(follow_data['followed_id']).to eq(followed.id)
+          expect(follow_data['follower_name']).to eq(follower.name)
+          expect(follow_data['followed_name']).to eq(followed.name)
+          expect(follow_data['id']).to be_present
+          expect(follow_data['created_at']).to be_present
+          expect(follow_data['updated_at']).to be_present
+        end
+      end
+
+      context 'and follow relationship does not exist' do
+        it 'returns not found error' do
+          expect {
+            delete :destroy, params: { user_id: follower.id, followed_id: followed.id }
+          }.not_to change(Follow, :count)
+
+          expect(response).to have_http_status(:not_found)
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['error']).to eq('Follow relationship not found')
+          expect(response_body['message']).to eq('You are not following this user')
+        end
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,55 +74,5 @@ RSpec.describe User, type: :model do
         expect(user2.followers).to contain_exactly(user1)
       end
     end
-
-    describe '#unfollow' do
-      context 'when follow relationship exists' do
-        before { user1.follow(user2) }
-
-        it 'removes the follow relationship' do
-          expect {
-            user1.unfollow(user2)
-          }.to change(Follow, :count).by(-1)
-
-          expect(user1.following?(user2)).to be false
-          expect(user2.followers).not_to include(user1)
-        end
-
-        it 'returns the destroyed follow object' do
-          follow = user1.active_follows.find_by(followed: user2)
-          result = user1.unfollow(user2)
-          expect(result).to eq(follow)
-        end
-      end
-
-      context 'when follow relationship does not exist' do
-        it 'returns nil and does not change follow count' do
-          expect {
-            result = user1.unfollow(user2)
-            expect(result).to be_nil
-          }.not_to change(Follow, :count)
-
-          expect(user1.following?(user2)).to be false
-        end
-      end
-
-      context 'with multiple follow relationships' do
-        before do
-          user1.follow(user2)
-          user1.follow(user3)
-          user3.follow(user1)
-        end
-
-        it 'only removes the specific follow relationship' do
-          expect {
-            user1.unfollow(user2)
-          }.to change(Follow, :count).by(-1)
-
-          expect(user1.following?(user2)).to be false
-          expect(user1.following?(user3)).to be true
-          expect(user3.following?(user1)).to be true
-        end
-      end
-    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,5 +74,55 @@ RSpec.describe User, type: :model do
         expect(user2.followers).to contain_exactly(user1)
       end
     end
+
+    describe '#unfollow' do
+      context 'when follow relationship exists' do
+        before { user1.follow(user2) }
+
+        it 'removes the follow relationship' do
+          expect {
+            user1.unfollow(user2)
+          }.to change(Follow, :count).by(-1)
+
+          expect(user1.following?(user2)).to be false
+          expect(user2.followers).not_to include(user1)
+        end
+
+        it 'returns the destroyed follow object' do
+          follow = user1.active_follows.find_by(followed: user2)
+          result = user1.unfollow(user2)
+          expect(result).to eq(follow)
+        end
+      end
+
+      context 'when follow relationship does not exist' do
+        it 'returns nil and does not change follow count' do
+          expect {
+            result = user1.unfollow(user2)
+            expect(result).to be_nil
+          }.not_to change(Follow, :count)
+
+          expect(user1.following?(user2)).to be false
+        end
+      end
+
+      context 'with multiple follow relationships' do
+        before do
+          user1.follow(user2)
+          user1.follow(user3)
+          user3.follow(user1)
+        end
+
+        it 'only removes the specific follow relationship' do
+          expect {
+            user1.unfollow(user2)
+          }.to change(Follow, :count).by(-1)
+
+          expect(user1.following?(user2)).to be false
+          expect(user1.following?(user3)).to be true
+          expect(user3.following?(user1)).to be true
+        end
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/follows_spec.rb
+++ b/spec/requests/api/v1/follows_spec.rb
@@ -138,8 +138,148 @@ RSpec.describe 'Api::V1::Follows', type: :request do
           second_response = JSON.parse(response.body)
           expect(second_response['error']).to eq('Unable to follow user')
 
-          # Verify we still have only 1 follow record
           expect(Follow.count).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/follows' do
+    context 'when user_id is not provided' do
+      it 'returns 401 unauthorized' do
+        delete '/api/v1/follows', params: { followed_id: followed.id }.to_json, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq({
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        })
+      end
+    end
+
+    context 'when user does not exist' do
+      it 'returns 401 unauthorized' do
+        delete '/api/v1/follows', params: { user_id: 999999, followed_id: followed.id }.to_json, headers: headers
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to eq({
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        })
+      end
+    end
+
+    context 'when followed_id is not provided' do
+      it 'returns 404 not found' do
+        delete '/api/v1/follows', params: { user_id: follower.id }.to_json, headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to eq({
+          'error' => 'User not found',
+          'message' => 'The user you want to unfollow does not exist'
+        })
+      end
+    end
+
+    context 'when followed user does not exist' do
+      it 'returns 404 not found' do
+        delete '/api/v1/follows', params: { user_id: follower.id, followed_id: 999999 }.to_json, headers: headers
+
+        expect(response).to have_http_status(:not_found)
+        expect(JSON.parse(response.body)).to eq({
+          'error' => 'User not found',
+          'message' => 'The user you want to unfollow does not exist'
+        })
+      end
+    end
+
+    context 'when both users exist' do
+      context 'and follow relationship exists' do
+        before { create(:follow, follower: follower, followed: followed) }
+
+        it 'destroys the follow relationship and returns 200' do
+          expect {
+            delete '/api/v1/follows', params: { user_id: follower.id, followed_id: followed.id }.to_json, headers: headers
+          }.to change(Follow, :count).by(-1)
+
+          expect(response).to have_http_status(:ok)
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['message']).to eq('Successfully unfollowed user')
+
+          follow_data = response_body['follow']
+          expect(follow_data['follower_id']).to eq(follower.id)
+          expect(follow_data['followed_id']).to eq(followed.id)
+          expect(follow_data['follower_name']).to eq(follower.name)
+          expect(follow_data['followed_name']).to eq(followed.name)
+          expect(follow_data['id']).to be_present
+          expect(follow_data['created_at']).to be_present
+          expect(follow_data['updated_at']).to be_present
+
+          # Verify the relationship was actually destroyed in the database
+          expect(Follow.exists?(follower: follower, followed: followed)).to be false
+        end
+      end
+
+      context 'and follow relationship does not exist' do
+        it 'returns 404 not found' do
+          expect {
+            delete '/api/v1/follows', params: { user_id: follower.id, followed_id: followed.id }.to_json, headers: headers
+          }.not_to change(Follow, :count)
+
+          expect(response).to have_http_status(:not_found)
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['error']).to eq('Follow relationship not found')
+          expect(response_body['message']).to eq('You are not following this user')
+        end
+      end
+
+      context 'integration test with complete follow/unfollow cycle' do
+        it 'handles the complete follow and unfollow flow' do
+          # Step 1: Create follow relationship
+          post '/api/v1/follows', params: { user_id: follower.id, followed_id: followed.id }.to_json, headers: headers
+
+          expect(response).to have_http_status(:created)
+          follow_response = JSON.parse(response.body)
+          expect(follow_response['message']).to eq('Successfully followed user')
+
+          follow_id = follow_response['follow']['id']
+
+          # Step 2: Verify relationship exists in database
+          follower.reload
+          followed.reload
+
+          expect(follower.following).to include(followed)
+          expect(followed.followers).to include(follower)
+          expect(follower.following?(followed)).to be true
+          expect(Follow.count).to eq(1)
+
+          # Step 3: Unfollow the user
+          delete '/api/v1/follows', params: { user_id: follower.id, followed_id: followed.id }.to_json, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          unfollow_response = JSON.parse(response.body)
+          expect(unfollow_response['message']).to eq('Successfully unfollowed user')
+
+          # Verify the returned follow data matches what was deleted
+          expect(unfollow_response['follow']['id']).to eq(follow_id)
+
+          # Step 4: Verify relationship no longer exists
+          follower.reload
+          followed.reload
+
+          expect(follower.following).not_to include(followed)
+          expect(followed.followers).not_to include(follower)
+          expect(follower.following?(followed)).to be false
+          expect(Follow.count).to eq(0)
+
+          # Step 5: Attempt to unfollow again (should fail)
+          delete '/api/v1/follows', params: { user_id: follower.id, followed_id: followed.id }.to_json, headers: headers
+
+          expect(response).to have_http_status(:not_found)
+          second_unfollow_response = JSON.parse(response.body)
+          expect(second_unfollow_response['error']).to eq('Follow relationship not found')
         end
       end
     end


### PR DESCRIPTION
## 📝 Summary

This PR implements the DELETE endpoint for the follows API, allowing users to unfollow other users. This completes the follow/unfollow functionality by adding the ability to remove existing follow relationships.

## 🎯 What Changed

### API Endpoint
- **Added `DELETE /api/v1/follows`** - New endpoint to unfollow users
- Accepts `user_id` (follower) and `followed_id` (user to unfollow) parameters
- Returns appropriate HTTP status codes and error messages for various scenarios

### Controllers
- **Enhanced `Api::V1::FollowsController`** with `destroy` action
  - Validates that both follower and followed users exist
  - Checks if follow relationship exists before attempting deletion
  - Returns detailed success/error responses with follow data

### Database Optimizations
- **Added composite index** on `follows` table: `[:follower_id, :followed_id]`
  - Optimizes follow relationship lookups significantly
  - Enforces uniqueness at database level
  - Removed redundant single-column index on `follower_id`
- **Updated migration**: `20250913165515_add_composite_index_to_follows.rb`

### Model Improvements
- **Updated `User#latest_sleep_record`** method
  - Changed from `order(created_at: :desc)` to `order(id: :desc)` for better performance
  - IDs are auto-incrementing and provide reliable ordering

### Documentation
- **Updated OpenAPI specification** (`docs/openapi.yml`)
  - Added complete documentation for the DELETE endpoint
  - Included request/response schemas
  - Documented all possible error scenarios
  - Added `FollowDeleteResponse` schema

### Testing
- **Comprehensive test coverage** for the new endpoint
  - Controller specs (`spec/controllers/api/v1/follows_controller_spec.rb`)
  - Request specs (`spec/requests/api/v1/follows_spec.rb`)
  - Integration test covering complete follow/unfollow cycle
  - Tests for all error scenarios (user not found, relationship not found, etc.)

## 🔧 Technical Details

### API Response Examples

#### Success (200):
```json
{
  "message": "Successfully unfollowed user",
  "follow": {
    "id": 123,
    "follower_id": 1,
    "followed_id": 2,
    "follower_name": "John Doe",
    "followed_name": "Jane Smith",
    "created_at": "2025-09-13T12:00:00.000Z",
    "updated_at": "2025-09-13T12:00:00.000Z"
  }
}
```

#### Error (404 - User not found):
```json
{
  "error": "User not found",
  "message": "The user you want to unfollow does not exist"
}
```

#### Error (404 - Relationship not found):

```json
{
  "error": "Follow relationship not found", 
  "message": "You are not following this user"
}
```
