### PR TITLE
feat(#15): Implement GET /api/v1/follows/sleep_records endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
       post "sleep_records", to: "sleep_records#create"
       post "follows", to: "follows#create"
       delete "follows", to: "follows#destroy"
+      get "follows/sleep_records", to: "follows#sleep_records"
     end
   end
 

--- a/db/migrate/20250913171236_add_index_to_sleep_records_bed_time.rb
+++ b/db/migrate/20250913171236_add_index_to_sleep_records_bed_time.rb
@@ -1,0 +1,8 @@
+class AddIndexToSleepRecordsBedTime < ActiveRecord::Migration[8.0]
+  def change
+    # Add index on bed_time for efficient ordering in the follows/sleep_records endpoint
+    # This optimizes queries like: sleep_records.order(bed_time: :desc)
+    # Used in: FollowsController#sleep_records for chronological ordering
+    add_index :sleep_records, :bed_time, name: 'index_sleep_records_on_bed_time'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_13_165515) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_13_171236) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_13_165515) do
     t.datetime "wakeup_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["bed_time"], name: "index_sleep_records_on_bed_time"
     t.index ["user_id"], name: "index_sleep_records_on_user_id"
   end
 

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -190,6 +190,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/RateLimitErrorResponse'
 
+  /api/v1/follows/sleep_records:
+    get:
+      summary: Get sleep records of followed users
+      description: |
+        Retrieves sleep records of users that the current user follows.
+        Results are ordered by bed_time in descending order (most recent first).
+        
+        **Business Logic:**
+        - Only returns sleep records from users that the current user follows
+        - Results are paginated with a default limit of 25 records
+        - Maximum limit is capped at 100 records per page
+        - Returns empty array if user doesn't follow anyone
+        - Includes user information along with sleep record data
+      operationId: getFollowedUsersSleepRecords
+      tags:
+        - Follows
+      parameters:
+        - name: user_id
+          in: query
+          required: true
+          schema:
+            type: integer
+          description: The ID of the current user
+          example: 1
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: Page number for pagination
+          example: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+          description: Number of records per page (max 100)
+          example: 25
+      responses:
+        '200':
+          description: Sleep records retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FollowedSleepRecordsResponse'
+        '401':
+          description: Unauthorized - user not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Unprocessable Entity - invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Too Many Requests - rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitErrorResponse'
+
 components:
   schemas:
     SleepRecord:
@@ -354,6 +423,103 @@ components:
       required:
         - message
         - follow
+
+    SleepRecordWithUser:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Unique identifier for the sleep record
+          example: 1
+        user_id:
+          type: integer
+          description: ID of the user this sleep record belongs to
+          example: 2
+        user_name:
+          type: string
+          description: Name of the user who owns this sleep record
+          example: "Jane Smith"
+        bed_time:
+          type: string
+          format: date-time
+          description: When the user went to bed (ISO 8601 format)
+          example: "2023-12-25T22:00:00Z"
+        wakeup_time:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the user woke up (ISO 8601 format), null if still sleeping
+          example: "2023-12-26T08:00:00Z"
+        duration_in_hours:
+          type: number
+          nullable: true
+          description: Duration of sleep in hours, null if still sleeping
+          example: 10.0
+        sleeping:
+          type: boolean
+          description: Whether the user is currently sleeping (wakeup_time is null)
+          example: false
+        created_at:
+          type: string
+          format: date-time
+          description: When the record was created (ISO 8601 format)
+          example: "2023-12-25T22:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: When the record was last updated (ISO 8601 format)
+          example: "2023-12-26T08:00:00Z"
+      required:
+        - id
+        - user_id
+        - user_name
+        - bed_time
+        - sleeping
+        - created_at
+        - updated_at
+
+    PaginationInfo:
+      type: object
+      properties:
+        current_page:
+          type: integer
+          description: Current page number
+          example: 1
+        per_page:
+          type: integer
+          description: Number of records per page
+          example: 25
+        total_pages:
+          type: integer
+          description: Total number of pages
+          example: 5
+        total_count:
+          type: integer
+          description: Total number of records
+          example: 123
+      required:
+        - current_page
+        - per_page
+        - total_pages
+        - total_count
+
+    FollowedSleepRecordsResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: "Sleep records retrieved successfully"
+        sleep_records:
+          type: array
+          items:
+            $ref: '#/components/schemas/SleepRecordWithUser'
+          description: Array of sleep records from followed users
+        pagination:
+          $ref: '#/components/schemas/PaginationInfo'
+      required:
+        - message
+        - sleep_records
+        - pagination
 
 tags:
   - name: Sleep Records

--- a/spec/controllers/api/v1/follows_controller_spec.rb
+++ b/spec/controllers/api/v1/follows_controller_spec.rb
@@ -189,4 +189,159 @@ RSpec.describe Api::V1::FollowsController, type: :controller do
       end
     end
   end
+
+  describe 'GET #sleep_records' do
+    let(:user1) { create(:user, name: 'User1') }
+    let(:user2) { create(:user, name: 'User2') }
+    let(:user3) { create(:user, name: 'User3') }
+    let(:current_user) { create(:user, name: 'CurrentUser') }
+
+    context 'when user_id is not provided' do
+      it 'returns unauthorized error' do
+        get :sleep_records
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        )
+      end
+    end
+
+    context 'when user does not exist' do
+      it 'returns unauthorized error' do
+        get :sleep_records, params: { user_id: 999999 }
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'User not found',
+          'message' => 'Please provide a valid user_id parameter'
+        )
+      end
+    end
+
+    context 'when user exists but follows no one' do
+      it 'returns empty sleep records with pagination' do
+        get :sleep_records, params: { user_id: current_user.id }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        expect(response_body['message']).to eq('No sleep records found')
+        expect(response_body['sleep_records']).to eq([])
+        expect(response_body['pagination']).to include(
+          'current_page' => 1,
+          'per_page' => 25,
+          'total_pages' => 0,
+          'total_count' => 0
+        )
+      end
+    end
+
+    context 'when user follows others with sleep records' do
+      let!(:follow1) { create(:follow, follower: current_user, followed: user1) }
+      let!(:follow2) { create(:follow, follower: current_user, followed: user2) }
+      let!(:sleep_record1) { create(:sleep_record, user: user1, bed_time: 2.days.ago, wakeup_time: 1.day.ago) }
+      let!(:sleep_record2) { create(:sleep_record, user: user2, bed_time: 1.day.ago, wakeup_time: Time.current) }
+      let!(:sleep_record3) { create(:sleep_record, user: user3, bed_time: 3.days.ago, wakeup_time: 2.days.ago) } # user3 not followed
+
+      it 'returns sleep records from followed users only, ordered by bed_time desc' do
+        get :sleep_records, params: { user_id: current_user.id }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        expect(response_body['message']).to eq('Sleep records retrieved successfully')
+        expect(response_body['sleep_records'].length).to eq(2)
+        
+        # Check ordering (most recent bed_time first)
+        sleep_records = response_body['sleep_records']
+        expect(sleep_records[0]['user_id']).to eq(user2.id)
+        expect(sleep_records[1]['user_id']).to eq(user1.id)
+        
+        # Check that user3's sleep record is not included
+        user_ids = sleep_records.map { |sr| sr['user_id'] }
+        expect(user_ids).not_to include(user3.id)
+        
+        # Check sleep record structure
+        first_record = sleep_records[0]
+        expect(first_record).to include(
+          'id' => sleep_record2.id,
+          'user_id' => user2.id,
+          'user_name' => 'User2',
+          'bed_time' => sleep_record2.bed_time.iso8601,
+          'wakeup_time' => sleep_record2.wakeup_time.iso8601,
+          'duration_in_hours' => sleep_record2.duration_in_hours,
+          'sleeping' => false
+        )
+        
+        # Check pagination
+        expect(response_body['pagination']).to include(
+          'current_page' => 1,
+          'per_page' => 25,
+          'total_pages' => 1,
+          'total_count' => 2
+        )
+      end
+
+      it 'handles pagination correctly' do
+        # Ensure we have exactly 2 records for this test
+        expect(SleepRecord.where(user_id: [user1.id, user2.id]).count).to eq(2)
+        
+        get :sleep_records, params: { user_id: current_user.id, page: 2, limit: 1 }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        expect(response_body['sleep_records'].length).to eq(1)
+        expect(response_body['sleep_records'][0]['user_id']).to eq(user1.id)
+        
+        expect(response_body['pagination']).to include(
+          'current_page' => 2,
+          'per_page' => 1,
+          'total_pages' => 2,
+          'total_count' => 2
+        )
+      end
+
+      it 'caps limit at 100' do
+        get :sleep_records, params: { user_id: current_user.id, limit: 150 }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        expect(response_body['pagination']['per_page']).to eq(100)
+      end
+
+      it 'uses default values for invalid pagination parameters' do
+        get :sleep_records, params: { user_id: current_user.id, page: -1, limit: 0 }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        expect(response_body['pagination']).to include(
+          'current_page' => 1,
+          'per_page' => 25
+        )
+      end
+
+      it 'includes sleeping records correctly' do
+        # Create a sleeping record (no wakeup_time)
+        sleeping_record = create(:sleep_record, user: user1, bed_time: Time.current, wakeup_time: nil)
+        
+        get :sleep_records, params: { user_id: current_user.id }
+        
+        expect(response).to have_http_status(:ok)
+        response_body = JSON.parse(response.body)
+        
+        # Should now have 3 records (2 existing + 1 sleeping)
+        expect(response_body['sleep_records'].length).to eq(3)
+        
+        # The sleeping record should be first (most recent bed_time)
+        first_record = response_body['sleep_records'][0]
+        expect(first_record['id']).to eq(sleeping_record.id)
+        expect(first_record['sleeping']).to eq(true)
+        expect(first_record['wakeup_time']).to be_nil
+        expect(first_record['duration_in_hours']).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds a new endpoint to retrieve sleep records from users that the current user follows, ordered by most recent bed time.

## Changes
- **Controller**: Added `sleep_records` action to `FollowsController` with pagination support
- **Routes**: Added `GET /api/v1/follows/sleep_records` route
- **Database**: Added index on `sleep_records.bed_time` for optimized ordering
- **API Documentation**: Updated OpenAPI spec with complete endpoint documentation
- **Tests**: Added comprehensive controller and request specs with edge cases

## Features
- Returns sleep records from followed users only
- Ordered by bed time (descending, most recent first)  
- Pagination support (default 25, max 100 per page)
- Includes user information with each sleep record
- Handles sleeping users (no wakeup time) correctly
- Empty result handling when user follows no one

## API Response
```json
{
  "message": "Sleep records retrieved successfully", 
  "sleep_records": [...],
  "pagination": { "current_page": 1, "per_page": 25, "total_pages": 2, "total_count": 45 }
}
```

Closes #15 